### PR TITLE
Add Google Translate API instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 ### Git Info
 ![github-size]  ![github-activity] ![github-latest] ![github-beta-backlog] ![github-stars]
 
+### Localization
+To translate the entire English localization directory into German run:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+pip install google-cloud-translate
+python scripts/translate_directory_to_german.py localisation/english localisation/german
+```
+
+These helper scripts rely on the official **Google Translate API**. You will
+need a service account JSON key to authenticate. Create a Google Cloud project,
+enable the **Cloud Translation API** and download a service account key file.
+Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to that
+file before running the translation commands. Each English `.yml` file is then
+converted into its German counterpart (with `_l_german` filenames) using
+Google's translation service.
+
 [patreon-badge]: https://img.shields.io/static/v1?label=Patreon&message=Donate&color=orange&logo=patreon&style=for-the-badge
 [patreon-link]: http://patreon.com/RONMOD
 

--- a/localisation/german/AC_l_german.yml
+++ b/localisation/german/AC_l_german.yml
@@ -1,0 +1,96 @@
+l_german:
+ AC_DECISIONS:0 "Bauvorhaben"
+ AC_DECISIONS_desc:0 "Unsere Bauprojekte in alliierten Ländern."
+
+ AC_construction_CICx1_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx1_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx2_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx2_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx3_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx3_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx4_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx4_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx5_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx5_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+
+ AC_construction_CICx6_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx6_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx7_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx7_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx8_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx8_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx9_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx9_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+
+ AC_construction_CICx10_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx10_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx11_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx11_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx12_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx12_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx13_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx13_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ AC_construction_CICx14_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx14_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+
+ AC_construction_CICx15_decision:0 "Bauen von [?AC_build_amount_queue]x [AC_GetConstructionType] in [From.GetName]"
+ AC_construction_CICx15_decision_desc:0 "Gesamtzeit bis zum Ende der Warteschlange: [?AC_total_construction_duration] days\nTotal construction speed modifikator: x[?AC_construction_speed_display]\n\nKlicken Sie mit der rechten Maustaste auf den Zielzustand."
+ 
+ AC_construction_CANCEL_decision:0 "Bauprojekt abbrechen"
+ AC_construction_CANCEL_decision_desc:0 "Erstattet die politischen Machtkosten für die unvollendeten Gebäude."
+ 
+ AC_target_country_DECISIONS:0 "Bauvorhaben"
+ AC_target_country_DECISIONS_desc:0 "Allied Bauprojekte in unserem Land."
+ 
+ AC_construction_target_decision:0 "[From.GetName]: Konstruktion [From.AC_GetConstructionType]."
+ AC_construction_target_decision_desc:0 "Wenn Sie diese Mission auswählen, wird das Bauprojekt abgebrochen.\n\nRechtsklicken Sie, um den Zielzustand zu sehen."
+ 
+ AC_construction_INF:0 "Infrastructure\n\n§YPolitische Stromkosten pro Gebäude:§! §R5§!"
+ AC_construction_AIR:0 "Air Base\n\n§YPolitische Stromkosten pro Gebäude:§! §R2.5§!"
+ AC_construction_AA:0 "Anti-Luft-n\n§YPolitische Stromkosten pro Gebäude:§! §R2.5§!"
+ AC_construction_RAD:0 "Radar\n\n§YPolitische Stromkosten pro Gebäude:§! §R10§!"
+ 
+ AC_construction_MIC:0 "Militärische Fabrik\n\n§YPolitische Stromkosten pro Gebäude:§! §R10§!"
+ AC_construction_CIC:0 "Civilian Factory\n\n§YPolitische Stromkosten pro Gebäude:§! §R15§!"
+ AC_construction_NIC:0 "Dockyard\n\n§YPolitische Stromkosten pro Gebäude:§! §R10§!"
+ AC_construction_REF:0 "Raffinerie\n\n§YPolitische Stromkosten pro Gebäude:§! §R20§!"
+ 
+ AC_assigned_factories_button_tt:0 "Wählen Sie aus, wie viele Ihrer zivilen Fabriken Sie diesem Bauprojekt zuweisen möchten.\n\n§YFactories für Projekte verfügbar:§! §G[?Root.num_of_civilian_factories_available_for_projects]§!\n\n§Lshift-click um 5.§ hinzuzufügen oder zu entfernen!"
+ 
+ AC_building_amount_increase_button_tt:0 "Wählen Sie aus, wie viele Gebäude des ausgewählten Typs Sie in diesem Zustand konstruieren möchten.\n\n§YMaximale Menge hängt vom Gebäude, den freien Slots im Zustand und Ihren Technologien ab.\n\nSie können Gebäude auf Slots anstellen, die der Controller bereits für den Bau reserviert hat, wenn die Gebäudetypen gleich sind. Projekt wird am Ende des Baus abgebrochen, wenn keine kostenlosen Slots verfügbar sind.§!\n\n§Lshift-klicken Sie, um 5.§ hinzuzufügen oder zu entfernen!"
+ 
+ AC_political_power_cost_tt:0 "\n\n§YPolitische Macht erforderlich:§! §R[?Root.AC_political_power_cost]§!"
+ 
+ AC_allied_construction_icon1_tt:0 "Allied Construction Projects\n\n§LErstellen Sie ein Bauprojekt im Staat Ihres Verbündeten.§!"
+ 
+ AC_build_button_text:0 "[AC_GetBuildButtonText]"
+ AC_start_project:0 "Projekt starten"
+ AC_cancel_project:0 "Projekt abbrechen"
+ AC_build_button_tt:0 "Wenn Sie diesen Knopf drücken, wird eine Erlaubnis vom Controller des Staates angefordert.Wenn sie akzeptieren, beginnt ein Bauprojekt in Ihrer Entscheidungstabelle.Dieses Projekt wiederholt sich, bis alle anstehenden Gebäude abgeschlossen sind.\n\n§YBaugeschwindigkeit nimmt eine -25% Strafe auf, was es normalerweise sein würde (die Baugeschwindigkeitmodifikatoren Ihres Landes gelten).§![Von.AC_GetPoliticalPowerCost]\n\n§LSie können nur ein aktives Bauprojekt zu einer Zeit haben.\n\nEin Staat kann kein Bauprojekt aus mehreren Ländern aktiv haben.\n\nDer Controller dieses Staates wird ablehnen, wenn er eine negative Meinung von Ihnen hat.§!"
+ 
+ AC_assist_repair_button_text:0 "Hilfsreparatur"
+ AC_assist_repair_button_tt:0 "Helfen Sie diesem Land bei der Reparatur von Gebäuden.\n\n§YPolitische Leistung Tagesgewinn:§! §R-1§!\n\n§YDauer:§!§! §G180 Tage\n\n§LSie können nur ein Land gleichzeitig bei Reparaturen unterstützen.\n\nSie können Reparaturhilfe durch Anklicken dieser Schaltfläche oder durch die Registerkarte Entscheidungen jederzeit stornieren.Es gibt eine Abklingzeit von einem Tag, bevor Sie es wieder aktivieren können.§!"
+
+ AC_construction_opinion:0 "Bauvorhaben"
+ 
+ AC_event.1.t:0 "Antrag auf Baugenehmigung"
+ AC_event.1.d:0 "[From.GetName] fordert eine Erlaubnis zum Konstruieren von [?From.AC_build_amount_queue]x [From.AC_GetConstructionType] in [AC_state_event_target.GetName]."
+ AC_event.1.o1:0 "Akzeptieren"
+ AC_event.1.o2:0 "Weigerung"
+ 
+ AC_event.2.t:0 "Baugenehmigung verweigert"
+ AC_event.2.d:0 "[From.GetName] hat unsere Anfrage für ein Bauprojekt in [AC_state_event_target.GetName] abgelehnt."
+ AC_event.2.o1:0 "Verstehe."
+ 
+ AC_event.3.t:0 "Bauvorhaben abgebrochen"
+ AC_event.3.d:0 "[From.GetName] hat unser Bauprojekt abgebrochen."
+ AC_event.3.o1:0 "Verstehe."
+
+ AC_assist_repair_target_idea:0 "Reparaturhilfe"
+ AC_assist_repair_target_idea_desc:0 "Dieses Land erhält Reparaturhilfe von einem seiner Verbündeten."
+
+ AC_assist_repair_decision:0 "Reparaturhilfe"
+ AC_assist_repair_decision_desc:0 "Derzeit unterstützen wir einen Verbündeten bei Reparaturen.\n\n§LRechtsklick, um das Zielland zu sehen.§!"
+
+ AC_assist_repair_CANCEL_decision:0 "Reparaturhilfe abbrechen"
+ AC_assist_repair_CANCEL_decision_desc:0 "Reparaturhilfe abbrechen."

--- a/scripts/translate_directory_to_german.py
+++ b/scripts/translate_directory_to_german.py
@@ -1,0 +1,49 @@
+import os
+import re
+import sys
+from pathlib import Path
+from google.cloud import translate_v2 as translate
+client = translate.Client()
+pattern = re.compile(r'^(\s*[^#\s][^:]*:\d+\s*")(.*)(".*)$')
+
+
+def translate_line(line: str) -> str:
+    match = pattern.match(line)
+    if match:
+        prefix, text, suffix = match.groups()
+        try:
+            translated = client.translate(text, target_language='de')
+            translated_text = translated['translatedText']
+        except Exception:
+            translated_text = text
+        return f"{prefix}{translated_text}{suffix}\n"
+    # translate the header line l_english:
+    if line.strip() == 'l_english:' or line.strip() == '\ufeffl_english:':
+        return line.replace('l_english', 'l_german')
+    return line
+
+
+def translate_file(src: Path, dest: Path):
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with src.open('r', encoding='utf-8-sig') as f:
+        lines = [translate_line(line) for line in f]
+    with dest.open('w', encoding='utf-8') as out:
+        out.writelines(lines)
+
+
+def translate_directory(src_dir: Path, dest_dir: Path):
+    for root, _, files in os.walk(src_dir):
+        for file in files:
+            if file.endswith('.yml'):
+                src_path = Path(root) / file
+                rel = src_path.relative_to(src_dir)
+                dest_path = dest_dir / rel
+                dest_path = Path(str(dest_path).replace('_l_english', '_l_german'))
+                translate_file(src_path, dest_path)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: translate_directory_to_german.py <english_dir> <german_dir>')
+        sys.exit(1)
+    translate_directory(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/scripts/translate_to_german.py
+++ b/scripts/translate_to_german.py
@@ -1,0 +1,35 @@
+import os
+import re
+import sys
+from google.cloud import translate_v2 as translate
+
+client = translate.Client()
+pattern = re.compile(r'^(\s*[^#\s][^:]*:\d+\s*")(.*)(".*)$')
+
+def translate_line(line: str) -> str:
+    match = pattern.match(line)
+    if match:
+        prefix, text, suffix = match.groups()
+        try:
+            translated = client.translate(text, target_language='de')
+            translated_text = translated['translatedText']
+        except Exception:
+            translated_text = text
+        return f"{prefix}{translated_text}{suffix}\n"
+    if line.strip() == 'l_english:' or line.strip() == '\ufeffl_english:':
+        return line.replace('l_english', 'l_german')
+    return line
+
+
+def translate_file(eng_path: str, ger_path: str):
+    with open(eng_path, 'r', encoding='utf-8-sig') as f:
+        lines = [translate_line(line) for line in f]
+    with open(ger_path, 'w', encoding='utf-8') as out:
+        out.writelines(lines)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: translate_to_german.py <english_file> <german_file>")
+        sys.exit(1)
+    translate_file(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- integrate Google Cloud Translate for the helper scripts
- document how to use the API with service account credentials

## Testing
- `pip install google-cloud-translate`
- `python scripts/translate_to_german.py localisation/english/AC_l_english.yml localisation/german/test_output.yml` *(fails: DefaultCredentialsError)*
- `python scripts/translate_directory_to_german.py localisation/english localisation/german/test_dir` *(fails: DefaultCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_688aa53ec78083319534f7788fabb71b