### PR TITLE
Add OAuth login to translation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,15 @@
 To translate the entire English localization directory into German run:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
-pip install google-cloud-translate
+pip install google-cloud-translate google-auth-oauthlib
 python scripts/translate_directory_to_german.py localisation/english localisation/german
 ```
 
-These helper scripts rely on the official **Google Translate API**. You will
-need a service account JSON key to authenticate. Create a Google Cloud project,
-enable the **Cloud Translation API** and download a service account key file.
-Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to that
-file before running the translation commands. Each English `.yml` file is then
-converted into its German counterpart (with `_l_german` filenames) using
-Google's translation service.
+Place the OAuth client secret JSON file from the Google Cloud console as
+`client_secret.json` in the repository root. The script launches a browser
+window for Google login and stores the resulting token in `token.json` for
+future runs. Each English `.yml` file is converted into its German counterpart
+(with `_l_german` filenames) using Google's translation service.
 
 [patreon-badge]: https://img.shields.io/static/v1?label=Patreon&message=Donate&color=orange&logo=patreon&style=for-the-badge
 [patreon-link]: http://patreon.com/RONMOD

--- a/scripts/translate_directory_to_german.py
+++ b/scripts/translate_directory_to_german.py
@@ -2,8 +2,40 @@ import os
 import re
 import sys
 from pathlib import Path
+
 from google.cloud import translate_v2 as translate
-client = translate.Client()
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = ["https://www.googleapis.com/auth/cloud-translation"]
+TOKEN_FILE = "token.json"
+CLIENT_SECRETS_FILE = "client_secret.json"
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not os.path.exists(CLIENT_SECRETS_FILE):
+                print(
+                    f"Missing {CLIENT_SECRETS_FILE}. Download it from the Google Cloud Console."
+                )
+                sys.exit(1)
+            flow = InstalledAppFlow.from_client_secrets_file(
+                CLIENT_SECRETS_FILE, SCOPES
+            )
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, "w") as token:
+            token.write(creds.to_json())
+    return creds
+
+
+client = translate.Client(credentials=get_credentials())
 pattern = re.compile(r'^(\s*[^#\s][^:]*:\d+\s*")(.*)(".*)$')
 
 

--- a/scripts/translate_to_german.py
+++ b/scripts/translate_to_german.py
@@ -1,9 +1,40 @@
 import os
 import re
 import sys
-from google.cloud import translate_v2 as translate
 
-client = translate.Client()
+from google.cloud import translate_v2 as translate
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = ["https://www.googleapis.com/auth/cloud-translation"]
+TOKEN_FILE = "token.json"
+CLIENT_SECRETS_FILE = "client_secret.json"
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not os.path.exists(CLIENT_SECRETS_FILE):
+                print(
+                    f"Missing {CLIENT_SECRETS_FILE}. Download it from the Google Cloud Console."
+                )
+                sys.exit(1)
+            flow = InstalledAppFlow.from_client_secrets_file(
+                CLIENT_SECRETS_FILE, SCOPES
+            )
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, "w") as token:
+            token.write(creds.to_json())
+    return creds
+
+
+client = translate.Client(credentials=get_credentials())
 pattern = re.compile(r'^(\s*[^#\s][^:]*:\d+\s*")(.*)(".*)$')
 
 def translate_line(line: str) -> str:


### PR DESCRIPTION
## Summary
- add OAuth helper to translation scripts so they open a browser for Google login
- adjust README with new instructions for OAuth-based translation helpers

## Testing
- `python -m py_compile scripts/translate_to_german.py scripts/translate_directory_to_german.py`
- `python scripts/translate_to_german.py` *(fails: Missing client_secret.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b1235573083318d7f9866a8ec1af4