### PR TITLE
Improve translation script output

### DIFF
--- a/scripts/translate_directory_to_german.py
+++ b/scripts/translate_directory_to_german.py
@@ -56,22 +56,40 @@ def translate_line(line: str) -> str:
 
 
 def translate_file(src: Path, dest: Path):
+    """Translate one file and save it to the destination."""
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with src.open('r', encoding='utf-8-sig') as f:
-        lines = [translate_line(line) for line in f]
-    with dest.open('w', encoding='utf-8') as out:
-        out.writelines(lines)
+    with src.open("r", encoding="utf-8-sig") as f:
+        lines = f.readlines()
+
+    print(f"  Translating {src} -> {dest} ({len(lines)} lines)...")
+    translated = [translate_line(line) for line in lines]
+
+    with dest.open("w", encoding="utf-8") as out:
+        out.writelines(translated)
 
 
 def translate_directory(src_dir: Path, dest_dir: Path):
+    """Translate all .yml files within ``src_dir`` to ``dest_dir``."""
+    files_to_translate = []
     for root, _, files in os.walk(src_dir):
         for file in files:
-            if file.endswith('.yml'):
+            if file.endswith(".yml"):
                 src_path = Path(root) / file
                 rel = src_path.relative_to(src_dir)
                 dest_path = dest_dir / rel
-                dest_path = Path(str(dest_path).replace('_l_english', '_l_german'))
-                translate_file(src_path, dest_path)
+                dest_path = Path(
+                    str(dest_path).replace("_l_english", "_l_german")
+                )
+                files_to_translate.append((src_path, dest_path))
+
+    total = len(files_to_translate)
+    print(f"Found {total} files to translate.")
+
+    for idx, (src_path, dest_path) in enumerate(files_to_translate, start=1):
+        print(f"[{idx}/{total}] Processing {src_path}")
+        translate_file(src_path, dest_path)
+
+    print("Translation complete.")
 
 
 if __name__ == '__main__':

--- a/scripts/translate_to_german.py
+++ b/scripts/translate_to_german.py
@@ -53,10 +53,17 @@ def translate_line(line: str) -> str:
 
 
 def translate_file(eng_path: str, ger_path: str):
-    with open(eng_path, 'r', encoding='utf-8-sig') as f:
-        lines = [translate_line(line) for line in f]
-    with open(ger_path, 'w', encoding='utf-8') as out:
-        out.writelines(lines)
+    """Translate a single localization file to German."""
+    with open(eng_path, "r", encoding="utf-8-sig") as f:
+        lines = f.readlines()
+
+    print(f"Translating {eng_path} -> {ger_path} ({len(lines)} lines)...")
+    translated = [translate_line(line) for line in lines]
+
+    with open(ger_path, "w", encoding="utf-8") as out:
+        out.writelines(translated)
+
+    print(f"Saved {ger_path}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- print progress when translating single files
- show per-file progress in directory translation script

## Testing
- `python -m py_compile scripts/translate_to_german.py scripts/translate_directory_to_german.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b41fa36c88331b149f4bff4447c58